### PR TITLE
Add AI-driven rule system

### DIFF
--- a/src/eidosian_universe/README.md
+++ b/src/eidosian_universe/README.md
@@ -5,11 +5,12 @@ A lightweight sandbox where autonomous agents evolve within a minimalistic cosmo
 ## Features
 
 - **Emergent behavior** driven by simple rules of movement and reproduction.
+- **Adaptive AI** periodically refines the universe's laws.
 - **Interactive controls**: click to spawn new agents, `ESC` to exit.
 - **Minimal requirements**: Python 3.10+, Pygame.
 
 ## Running
 
 ```bash
-python -m game_forge.src.eidosian_universe.eu_main
+PYTHONPATH=src python -m eidosian_universe.eu_main
 ```

--- a/src/eidosian_universe/__init__.py
+++ b/src/eidosian_universe/__init__.py
@@ -1,0 +1,6 @@
+"""Eidosian Universe package."""
+
+from .eu_ai import EidosAI
+from .eu_world import Universe
+
+__all__ = ["EidosAI", "Universe"]

--- a/src/eidosian_universe/eu_ai.py
+++ b/src/eidosian_universe/eu_ai.py
@@ -1,0 +1,33 @@
+"""Heuristic AI for refining universe rules during runtime."""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+    from .eu_world import Universe
+
+
+class EidosAI:
+    """Simple heuristic controller adjusting universe rules."""
+
+    def __init__(self, universe: Universe) -> None:
+        self.universe = universe
+        self._ticks = 0
+
+    def update(self) -> None:
+        """Potentially adjust rules based on universe state."""
+        self._ticks += 1
+        if self._ticks % 300 == 0:
+            self._tweak_gravity()
+
+    def _tweak_gravity(self) -> None:
+        gravity = self.universe.gravity
+        old = gravity.strength
+        new = max(0.01, min(0.2, old * random.uniform(0.95, 1.05)))
+        gravity.strength = new
+        self.universe.log_event(
+            f"Eidos refined gravity: {old:.3f} -> {new:.3f}"
+        )
+

--- a/src/eidosian_universe/eu_main.py
+++ b/src/eidosian_universe/eu_main.py
@@ -1,12 +1,27 @@
-"""Eidosian Universe: a simple emergent simulation."""
+"""Entry point for running the Eidosian Universe simulation."""
 
 from __future__ import annotations
 
 import sys
 import pygame
 
-from .eu_config import UniverseConfig
-from .eu_world import Universe
+# When executed directly, ``__package__`` will be ``None`` and relative imports
+# fail.  To support ``python eu_main.py`` from within the ``src`` directory we
+# manually adjust ``sys.path`` and use absolute imports.  When run as a module
+# (``python -m eidosian_universe.eu_main``) the relative imports work normally.
+
+if __package__ in (None, ""):
+    import os
+    import sys
+
+    sys.path.append(os.path.dirname(__file__))
+    from eidosian_universe.eu_config import UniverseConfig
+    from eidosian_universe.eu_world import Universe
+    from eidosian_universe.eu_ai import EidosAI
+else:
+    from .eu_config import UniverseConfig
+    from .eu_world import Universe
+    from .eu_ai import EidosAI
 
 
 def main() -> None:
@@ -16,6 +31,7 @@ def main() -> None:
     screen = pygame.display.set_mode((config.width, config.height))
     clock = pygame.time.Clock()
     universe = Universe(config)
+    ai = EidosAI(universe)
 
     running = True
     while running:
@@ -30,6 +46,7 @@ def main() -> None:
                     universe._create_random_agent()
                 )
 
+        ai.update()
         universe.update()
         universe.render(screen)
         pygame.display.flip()

--- a/src/eidosian_universe/eu_rules.py
+++ b/src/eidosian_universe/eu_rules.py
@@ -1,0 +1,38 @@
+"""Mutable rule definitions for the Eidosian Universe simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .eu_agent import Agent
+
+
+@dataclass
+class GravityRule:
+    """Simple gravitational attraction between agents."""
+
+    strength: float = 0.05
+    max_range: float = 100.0
+
+    def apply(self, agents: List[Agent]) -> None:
+        """Modify agent velocities based on mutual attraction."""
+        count = len(agents)
+        for i in range(count):
+            a = agents[i]
+            for j in range(i + 1, count):
+                b = agents[j]
+                dx = b.x - a.x
+                dy = b.y - a.y
+                dist_sq = dx * dx + dy * dy
+                if dist_sq == 0 or dist_sq > self.max_range ** 2:
+                    continue
+                dist = dist_sq ** 0.5
+                force = self.strength / (dist_sq)
+                ax = force * dx / dist
+                ay = force * dy / dist
+                a.dx += ax
+                a.dy += ay
+                b.dx -= ax
+                b.dy -= ay
+

--- a/src/eidosian_universe/eu_world.py
+++ b/src/eidosian_universe/eu_world.py
@@ -9,6 +9,7 @@ import pygame
 
 from .eu_agent import Agent
 from .eu_config import UniverseConfig
+from .eu_rules import GravityRule
 
 
 class Universe:
@@ -17,6 +18,8 @@ class Universe:
     def __init__(self, config: UniverseConfig) -> None:
         self.config = config
         self.agents: List[Agent] = []
+        self.gravity = GravityRule()
+        self.log: List[str] = []
         self._initialize_agents()
 
     def _initialize_agents(self) -> None:
@@ -37,6 +40,8 @@ class Universe:
 
     def update(self) -> None:
         """Advance simulation state."""
+        self.gravity.apply(self.agents)
+
         new_agents: List[Agent] = []
         for agent in list(self.agents):
             agent.update(self.config)
@@ -45,6 +50,11 @@ class Universe:
             if agent.energy <= 0:
                 self.agents.remove(agent)
         self.agents.extend(new_agents)
+
+    def log_event(self, message: str) -> None:
+        """Record an event in the universe log and print it."""
+        self.log.append(message)
+        print(message)
 
     def render(self, surface: pygame.Surface) -> None:
         """Draw all agents to the surface."""


### PR DESCRIPTION
## Summary
- expose Universe and AI in `__init__`
- add a simple heuristic AI to tweak gravity
- implement gravity rule and event log
- wire AI and rules into universe runner
- update module README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install pygame-ce`
- `PYTHONPATH=src python -m eidosian_universe.eu_main` *(fails: ALSA/XDG runtime errors but window opens until interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_684d922d3f28832384c6f82d936cef24