### PR TITLE
Expand Eidosian Universe simulation

### DIFF
--- a/src/eidosian_universe/README.md
+++ b/src/eidosian_universe/README.md
@@ -4,9 +4,10 @@ A lightweight sandbox where autonomous agents evolve within a minimalistic cosmo
 
 ## Features
 
-- **Emergent behavior** driven by simple rules of movement and reproduction.
-- **Adaptive AI** periodically refines the universe's laws.
-- **Interactive controls**: click to spawn new agents, `ESC` to exit.
+- **Emergent behavior** driven by complex agent properties and resource dynamics.
+- **Adaptive AI** periodically refines gravity and metabolic costs.
+- **Interactive controls**: click or tap to spawn agents, `ESC` to exit.
+- **Procedural resources** fuel agent growth and reproduction.
 - **Minimal requirements**: Python 3.10+, Pygame.
 
 ## Running
@@ -14,3 +15,6 @@ A lightweight sandbox where autonomous agents evolve within a minimalistic cosmo
 ```bash
 PYTHONPATH=src python -m eidosian_universe.eu_main
 ```
+
+The game launches in fullscreen by default. Click or tap anywhere to spawn
+additional agents.

--- a/src/eidosian_universe/eu_agent.py
+++ b/src/eidosian_universe/eu_agent.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
-from typing import Tuple
+from math import hypot
+from typing import List, Tuple
 
 
 @dataclass
@@ -16,13 +17,26 @@ class Agent:
     dx: float
     dy: float
     energy: float
+    mass: float
+    components: List[Tuple[float, float]]
     color: Tuple[int, int, int]
 
-    def update(self, config: "UniverseConfig") -> None:
-        """Update agent position and energy state."""
+    def update(
+        self,
+        config: "UniverseConfig",
+        resources: List["Resource"],
+        metabolism: "MetabolismRule",
+    ) -> None:
+        """Update agent position, energy, and interact with resources."""
         self.x += self.dx
         self.y += self.dy
-        self.energy -= config.energy_decay
+        move_cost = hypot(self.dx, self.dy) * self.mass * metabolism.movement_cost
+        self.energy -= config.energy_decay + move_cost
+        for res in resources:
+            if res.value > 0 and hypot(self.x - res.x, self.y - res.y) < config.agent_size * 2:
+                gained = min(res.value, metabolism.max_energy - self.energy)
+                self.energy += gained
+                res.value -= gained
 
         # Bounce on boundaries
         if self.x < 0 or self.x > config.width:
@@ -32,17 +46,19 @@ class Agent:
 
     def can_reproduce(self, config: "UniverseConfig") -> bool:
         """Return True if agent has enough energy to reproduce."""
-        return self.energy >= config.reproduction_energy
+        return self.energy >= config.reproduction_energy + config.reproduction_cost
 
     def reproduce(self, config: "UniverseConfig") -> "Agent":
         """Create a mutated child agent."""
-        self.energy *= 0.5
-        child_energy: float = self.energy
+        self.energy -= config.reproduction_cost
+        child_energy: float = config.reproduction_cost / 2
         return Agent(
             x=self.x + random.uniform(-10, 10),
             y=self.y + random.uniform(-10, 10),
             dx=random.uniform(-1, 1),
             dy=random.uniform(-1, 1),
             energy=child_energy,
+            mass=max(0.5, self.mass + random.uniform(-0.1, 0.1)),
+            components=[(x + random.uniform(-0.2, 0.2), y + random.uniform(-0.2, 0.2)) for x, y in self.components],
             color=tuple(min(255, max(0, c + random.randint(-20, 20))) for c in self.color),
         )

--- a/src/eidosian_universe/eu_ai.py
+++ b/src/eidosian_universe/eu_ai.py
@@ -21,6 +21,8 @@ class EidosAI:
         self._ticks += 1
         if self._ticks % 300 == 0:
             self._tweak_gravity()
+        if self._ticks % 500 == 0:
+            self._tweak_metabolism()
 
     def _tweak_gravity(self) -> None:
         gravity = self.universe.gravity
@@ -29,5 +31,14 @@ class EidosAI:
         gravity.strength = new
         self.universe.log_event(
             f"Eidos refined gravity: {old:.3f} -> {new:.3f}"
+        )
+
+    def _tweak_metabolism(self) -> None:
+        meta = self.universe.metabolism
+        old_move = meta.movement_cost
+        new_move = max(0.01, min(0.2, old_move * random.uniform(0.9, 1.1)))
+        meta.movement_cost = new_move
+        self.universe.log_event(
+            f"Eidos adjusted movement cost: {old_move:.3f} -> {new_move:.3f}"
         )
 

--- a/src/eidosian_universe/eu_config.py
+++ b/src/eidosian_universe/eu_config.py
@@ -6,12 +6,18 @@ from dataclasses import dataclass
 class UniverseConfig:
     """Settings controlling universe simulation parameters."""
 
-    width: int = 800
-    height: int = 600
+    width: int = 1024
+    height: int = 768
+    fullscreen: bool = True
     background_color: tuple[int, int, int] = (10, 10, 30)
     agent_count: int = 50
     max_agents: int = 200
     agent_size: int = 4
     energy_decay: float = 0.1
+    movement_cost: float = 0.05
     reproduction_energy: float = 80.0
+    reproduction_cost: float = 30.0
     starting_energy: float = 50.0
+    max_energy: float = 100.0
+    resource_count: int = 200
+    resource_value: float = 25.0

--- a/src/eidosian_universe/eu_main.py
+++ b/src/eidosian_universe/eu_main.py
@@ -28,7 +28,8 @@ def main() -> None:
     """Run the Eidosian Universe simulation."""
     pygame.init()
     config = UniverseConfig()
-    screen = pygame.display.set_mode((config.width, config.height))
+    flags = pygame.FULLSCREEN if config.fullscreen else 0
+    screen = pygame.display.set_mode((config.width, config.height), flags)
     clock = pygame.time.Clock()
     universe = Universe(config)
     ai = EidosAI(universe)
@@ -42,9 +43,11 @@ def main() -> None:
                 running = False
             if event.type == pygame.MOUSEBUTTONDOWN:
                 x, y = event.pos
-                universe.agents.append(
-                    universe._create_random_agent()
-                )
+                universe.agents.append(universe._create_random_agent(x=x, y=y))
+            if event.type == pygame.FINGERDOWN:
+                x = int(event.x * config.width)
+                y = int(event.y * config.height)
+                universe.agents.append(universe._create_random_agent(x=x, y=y))
 
         ai.update()
         universe.update()

--- a/src/eidosian_universe/eu_rules.py
+++ b/src/eidosian_universe/eu_rules.py
@@ -36,3 +36,19 @@ class GravityRule:
                 b.dx -= ax
                 b.dy -= ay
 
+
+@dataclass
+class MetabolismRule:
+    """Parameters governing energy costs and limits."""
+
+    movement_cost: float = 0.05
+    reproduction_cost: float = 30.0
+    max_energy: float = 100.0
+
+
+@dataclass
+class ResourceRule:
+    """Parameters controlling resource spawning."""
+
+    spawn_rate: int = 1
+

--- a/src/eidosian_universe/eu_world.py
+++ b/src/eidosian_universe/eu_world.py
@@ -3,13 +3,23 @@
 from __future__ import annotations
 
 import random
+from dataclasses import dataclass
 from typing import List
 
 import pygame
 
 from .eu_agent import Agent
 from .eu_config import UniverseConfig
-from .eu_rules import GravityRule
+from .eu_rules import GravityRule, MetabolismRule, ResourceRule
+
+
+@dataclass
+class Resource:
+    """Simple energy source within the universe."""
+
+    x: float
+    y: float
+    value: float
 
 
 class Universe:
@@ -18,25 +28,45 @@ class Universe:
     def __init__(self, config: UniverseConfig) -> None:
         self.config = config
         self.agents: List[Agent] = []
+        self.resources: List[Resource] = []
         self.gravity = GravityRule()
+        self.metabolism = MetabolismRule(
+            movement_cost=config.movement_cost,
+            reproduction_cost=config.reproduction_cost,
+            max_energy=config.max_energy,
+        )
+        self.resource_rule = ResourceRule()
         self.log: List[str] = []
         self._initialize_agents()
+        self._initialize_resources()
 
     def _initialize_agents(self) -> None:
         """Create initial population of agents."""
         for _ in range(self.config.agent_count):
             self.agents.append(self._create_random_agent())
 
-    def _create_random_agent(self) -> Agent:
+    def _create_random_agent(self, *, x: float | None = None, y: float | None = None) -> Agent:
         """Generate a random agent."""
         return Agent(
-            x=random.uniform(0, self.config.width),
-            y=random.uniform(0, self.config.height),
+            x=random.uniform(0, self.config.width) if x is None else x,
+            y=random.uniform(0, self.config.height) if y is None else y,
             dx=random.uniform(-1, 1),
             dy=random.uniform(-1, 1),
             energy=self.config.starting_energy,
+            mass=random.uniform(0.5, 2.0),
+            components=[(random.uniform(-1, 1), random.uniform(-1, 1)) for _ in range(random.randint(1, 3))],
             color=(random.randint(50, 255), random.randint(50, 255), random.randint(50, 255)),
         )
+
+    def _initialize_resources(self) -> None:
+        for _ in range(self.config.resource_count):
+            self.resources.append(
+                Resource(
+                    x=random.uniform(0, self.config.width),
+                    y=random.uniform(0, self.config.height),
+                    value=self.config.resource_value,
+                )
+            )
 
     def update(self) -> None:
         """Advance simulation state."""
@@ -44,12 +74,24 @@ class Universe:
 
         new_agents: List[Agent] = []
         for agent in list(self.agents):
-            agent.update(self.config)
+            agent.update(self.config, self.resources, self.metabolism)
             if agent.can_reproduce(self.config) and len(self.agents) < self.config.max_agents:
                 new_agents.append(agent.reproduce(self.config))
             if agent.energy <= 0:
                 self.agents.remove(agent)
         self.agents.extend(new_agents)
+
+        # remove depleted resources
+        self.resources = [r for r in self.resources if r.value > 0]
+        # respawn resources as needed
+        while len(self.resources) < self.config.resource_count:
+            self.resources.append(
+                Resource(
+                    x=random.uniform(0, self.config.width),
+                    y=random.uniform(0, self.config.height),
+                    value=self.config.resource_value,
+                )
+            )
 
     def log_event(self, message: str) -> None:
         """Record an event in the universe log and print it."""
@@ -59,6 +101,13 @@ class Universe:
     def render(self, surface: pygame.Surface) -> None:
         """Draw all agents to the surface."""
         surface.fill(self.config.background_color)
+        for res in self.resources:
+            pygame.draw.circle(
+                surface,
+                (0, 200, 100),
+                (int(res.x), int(res.y)),
+                max(2, int(self.config.agent_size / 2)),
+            )
         for agent in self.agents:
             pygame.draw.circle(
                 surface,

--- a/tests/test_eidosian_universe.py
+++ b/tests/test_eidosian_universe.py
@@ -1,0 +1,30 @@
+import os
+os.environ['SDL_VIDEODRIVER'] = 'dummy'
+import pygame
+pygame.init()
+
+from eidosian_universe.eu_world import Universe, Resource
+from eidosian_universe.eu_config import UniverseConfig
+
+
+def test_agent_consumes_resource():
+    config = UniverseConfig()
+    uni = Universe(config)
+    agent = uni.agents[0]
+    res = Resource(x=agent.x, y=agent.y, value=10.0)
+    uni.resources = [res]
+    old_energy = agent.energy
+    agent.update(config, uni.resources, uni.metabolism)
+    assert agent.energy > old_energy
+    assert uni.resources[0].value < 10.0
+
+
+def test_agent_reproduction():
+    config = UniverseConfig()
+    uni = Universe(config)
+    agent = uni.agents[0]
+    agent.energy = config.reproduction_energy + config.reproduction_cost
+    child = agent.reproduce(config)
+    assert child is not None
+    assert agent.energy == config.reproduction_energy
+    assert child.energy == config.reproduction_cost / 2


### PR DESCRIPTION
## Summary
- greatly extend the Eidosian Universe demo
- add resources, mass and body components for agents
- expose metabolism settings and allow the AI to tweak them
- support fullscreen and touch input
- document new features
- add basic unit tests

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684d94c1e650832383b33876b4812b5d